### PR TITLE
Stop reading secrets in dev GH actions

### DIFF
--- a/.github/workflows/develop_pr_checks.yml
+++ b/.github/workflows/develop_pr_checks.yml
@@ -34,7 +34,9 @@ jobs:
           java-version: 11
 
       - name: Make local.properties
-        run: touch local.properties & echo -e "mapbox.downloads.token=${{ secrets.MAPBOX_SDK_DOWNLOAD_TOKEN }}" >> local.properties
+        env:
+          MAPBOX_DEV_TOKEN: sk.eyJ1IjoiYWtob2k5MCIsImEiOiJjbGUwMjNxa3AwNDEzM3Fyejh6b2ZrNGw3In0.mSo-Z30lqYW4K2Ime0z62g
+        run: echo -e "mapbox.downloads.token=$MAPBOX_DOWNLOAD_TOKEN" > local.properties
 
       - name: Build Debug APK
         run: bash ./gradlew :app:assembleDebug


### PR DESCRIPTION
Due to missing permissions, GH action can't read secrets in PR from fork.
ref: https://github.com/actions/add-to-project/issues/163